### PR TITLE
refactor(navigation-sample): remove unused imports

### DIFF
--- a/navigation/sample/app/src/main/java/si/inova/kotlinova/navigation/sample/MainActivity.kt
+++ b/navigation/sample/app/src/main/java/si/inova/kotlinova/navigation/sample/MainActivity.kt
@@ -16,29 +16,20 @@
 
 package si.inova.kotlinova.navigation.sample
 
-import android.app.Activity
-import android.content.Intent
 import android.os.Bundle
-import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Modifier
-import androidx.core.util.Consumer
 import androidx.fragment.app.FragmentActivity
 import com.deliveryhero.whetstone.Whetstone
 import com.deliveryhero.whetstone.activity.ContributesActivityInjector
-import com.zhuinden.simplestack.Backstack
 import com.zhuinden.simplestack.History
 import si.inova.kotlinova.navigation.deeplink.HandleNewIntentDeepLinks
 import si.inova.kotlinova.navigation.deeplink.MainDeepLinkHandler
 import si.inova.kotlinova.navigation.di.NavigationContext
-import si.inova.kotlinova.navigation.di.NavigationContextImpl
 import si.inova.kotlinova.navigation.di.NavigationInjection
-import si.inova.kotlinova.navigation.navigator.Navigator
 import si.inova.kotlinova.navigation.sample.keys.MainScreenKey
 import si.inova.kotlinova.navigation.sample.ui.theme.NavigationSampleTheme
 import si.inova.kotlinova.navigation.simplestack.RootNavigationContainer

--- a/navigation/sample/app/src/main/java/si/inova/kotlinova/navigation/sample/NavigationSampleApplication.kt
+++ b/navigation/sample/app/src/main/java/si/inova/kotlinova/navigation/sample/NavigationSampleApplication.kt
@@ -20,7 +20,6 @@ import android.app.Application
 import com.deliveryhero.whetstone.app.ApplicationComponent
 import com.deliveryhero.whetstone.app.ApplicationComponentOwner
 import com.deliveryhero.whetstone.app.ContributesAppInjector
-import si.inova.kotlinova.navigation.sample.DaggerNavigationSampleApplicationComponent
 
 @ContributesAppInjector(generateAppComponent = false)
 class NavigationSampleApplication : Application(), ApplicationComponentOwner {

--- a/navigation/sample/conditional/src/main/java/si/inova/kotlinova/navigation/sample/conditional/LoginScreen.kt
+++ b/navigation/sample/conditional/src/main/java/si/inova/kotlinova/navigation/sample/conditional/LoginScreen.kt
@@ -18,20 +18,14 @@ package si.inova.kotlinova.navigation.sample.conditional
 
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.material3.Button
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.ui.Alignment
 import kotlinx.parcelize.Parcelize
 import si.inova.kotlinova.navigation.instructions.GoBack
 import si.inova.kotlinova.navigation.instructions.MultiNavigationInstructions
 import si.inova.kotlinova.navigation.instructions.NavigationInstruction
-import si.inova.kotlinova.navigation.instructions.goBack
 import si.inova.kotlinova.navigation.navigator.Navigator
-import si.inova.kotlinova.navigation.sample.keys.RootConditionalNavigationScreenKey
 import si.inova.kotlinova.navigation.screenkeys.ScreenKey
 import si.inova.kotlinova.navigation.screens.Screen
 

--- a/navigation/sample/conditional/src/main/java/si/inova/kotlinova/navigation/sample/conditional/PostLoginScreenDeepLinkHandler.kt
+++ b/navigation/sample/conditional/src/main/java/si/inova/kotlinova/navigation/sample/conditional/PostLoginScreenDeepLinkHandler.kt
@@ -22,12 +22,10 @@ import si.inova.kotlinova.navigation.deeplink.DeepLinkHandler
 import si.inova.kotlinova.navigation.deeplink.matchDeepLink
 import si.inova.kotlinova.navigation.di.OuterNavigationScope
 import si.inova.kotlinova.navigation.instructions.ClearBackstackAnd
-import si.inova.kotlinova.navigation.instructions.MultiNavigationInstructions
 import si.inova.kotlinova.navigation.instructions.NavigateWithConditions
 import si.inova.kotlinova.navigation.instructions.NavigationInstruction
 import si.inova.kotlinova.navigation.instructions.OpenScreenOrMoveToTop
 import si.inova.kotlinova.navigation.instructions.ReplaceBackstack
-import si.inova.kotlinova.navigation.instructions.ReplaceBackstackOrOpenScreen
 import si.inova.kotlinova.navigation.sample.keys.MainScreenKey
 import javax.inject.Inject
 

--- a/navigation/sample/conditional/src/main/java/si/inova/kotlinova/navigation/sample/conditional/RootConditionalNavigationScreen.kt
+++ b/navigation/sample/conditional/src/main/java/si/inova/kotlinova/navigation/sample/conditional/RootConditionalNavigationScreen.kt
@@ -16,7 +16,6 @@
 
 package si.inova.kotlinova.navigation.sample.conditional
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.material3.Button

--- a/navigation/sample/fragment/src/main/java/si/inova/kotlinova/navigation/sample/fragment/DemoFragment.kt
+++ b/navigation/sample/fragment/src/main/java/si/inova/kotlinova/navigation/sample/fragment/DemoFragment.kt
@@ -22,7 +22,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
-import androidx.annotation.Keep
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager

--- a/navigation/sample/keys/src/main/java/si/inova/kotlinova/navigation/sample/keys/DemoFragmentScreenKey.kt
+++ b/navigation/sample/keys/src/main/java/si/inova/kotlinova/navigation/sample/keys/DemoFragmentScreenKey.kt
@@ -18,7 +18,6 @@ package si.inova.kotlinova.navigation.sample.keys
 
 import kotlinx.parcelize.Parcelize
 import si.inova.kotlinova.navigation.fragment.FragmentScreenKey
-import si.inova.kotlinova.navigation.screenkeys.NoArgsScreenKey
 import si.inova.kotlinova.navigation.screenkeys.ScreenKey
 import java.util.UUID
 

--- a/navigation/sample/keys/src/main/java/si/inova/kotlinova/navigation/sample/keys/MainScreenKey.kt
+++ b/navigation/sample/keys/src/main/java/si/inova/kotlinova/navigation/sample/keys/MainScreenKey.kt
@@ -18,7 +18,6 @@ package si.inova.kotlinova.navigation.sample.keys
 
 import kotlinx.parcelize.Parcelize
 import si.inova.kotlinova.navigation.screenkeys.NoArgsScreenKey
-import si.inova.kotlinova.navigation.screenkeys.ScreenKey
 
 @Parcelize
 object MainScreenKey : NoArgsScreenKey()

--- a/navigation/sample/keys/src/main/java/si/inova/kotlinova/navigation/sample/keys/NestedScreenKey.kt
+++ b/navigation/sample/keys/src/main/java/si/inova/kotlinova/navigation/sample/keys/NestedScreenKey.kt
@@ -18,7 +18,6 @@ package si.inova.kotlinova.navigation.sample.keys
 
 import kotlinx.parcelize.Parcelize
 import si.inova.kotlinova.navigation.screenkeys.NoArgsScreenKey
-import si.inova.kotlinova.navigation.screenkeys.ScreenKey
 
 @Parcelize
 object NestedScreenKey : NoArgsScreenKey()

--- a/navigation/sample/keys/src/main/java/si/inova/kotlinova/navigation/sample/keys/SharedViewModelScreenKey.kt
+++ b/navigation/sample/keys/src/main/java/si/inova/kotlinova/navigation/sample/keys/SharedViewModelScreenKey.kt
@@ -17,7 +17,6 @@
 package si.inova.kotlinova.navigation.sample.keys
 
 import kotlinx.parcelize.Parcelize
-import si.inova.kotlinova.navigation.screenkeys.NoArgsScreenKey
 import si.inova.kotlinova.navigation.screenkeys.ScreenKey
 import java.util.UUID
 

--- a/navigation/sample/keys/src/main/java/si/inova/kotlinova/navigation/sample/keys/SlideAnimationScreenKey.kt
+++ b/navigation/sample/keys/src/main/java/si/inova/kotlinova/navigation/sample/keys/SlideAnimationScreenKey.kt
@@ -24,7 +24,6 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.with
 import com.zhuinden.simplestack.StateChange
 import kotlinx.parcelize.Parcelize
-import si.inova.kotlinova.navigation.screenkeys.NoArgsScreenKey
 import si.inova.kotlinova.navigation.screenkeys.ScreenKey
 import si.inova.kotlinova.navigation.simplestack.StateChangeResult
 

--- a/navigation/sample/nested/src/main/java/si/inova/kotlinova/navigation/sample/nested/NestedRoot.kt
+++ b/navigation/sample/nested/src/main/java/si/inova/kotlinova/navigation/sample/nested/NestedRoot.kt
@@ -27,7 +27,6 @@ import si.inova.kotlinova.navigation.instructions.navigateTo
 import si.inova.kotlinova.navigation.navigator.Navigator
 import si.inova.kotlinova.navigation.sample.keys.MainScreenKey
 import si.inova.kotlinova.navigation.screenkeys.NoArgsScreenKey
-import si.inova.kotlinova.navigation.screenkeys.ScreenKey
 import si.inova.kotlinova.navigation.screens.Screen
 
 class NestedRootScreen(

--- a/navigation/sample/nested/src/main/java/si/inova/kotlinova/navigation/sample/nested/NestedScreen.kt
+++ b/navigation/sample/nested/src/main/java/si/inova/kotlinova/navigation/sample/nested/NestedScreen.kt
@@ -17,17 +17,12 @@
 package si.inova.kotlinova.navigation.sample.nested
 
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import si.inova.kotlinova.navigation.sample.keys.MainScreenKey
 import si.inova.kotlinova.navigation.sample.keys.NestedScreenKey
 import si.inova.kotlinova.navigation.screens.NestedBackstackScreen
 import si.inova.kotlinova.navigation.screens.NestedNavigationScreenKey

--- a/navigation/sample/nested/src/main/java/si/inova/kotlinova/navigation/sample/nested/NestedScreenDeepLinkHandler.kt
+++ b/navigation/sample/nested/src/main/java/si/inova/kotlinova/navigation/sample/nested/NestedScreenDeepLinkHandler.kt
@@ -22,7 +22,6 @@ import si.inova.kotlinova.navigation.deeplink.DeepLinkHandler
 import si.inova.kotlinova.navigation.deeplink.matchDeepLink
 import si.inova.kotlinova.navigation.di.OuterNavigationScope
 import si.inova.kotlinova.navigation.instructions.NavigationInstruction
-import si.inova.kotlinova.navigation.instructions.OpenScreen
 import si.inova.kotlinova.navigation.instructions.OpenScreenOrMoveToTop
 import si.inova.kotlinova.navigation.instructions.ReplaceBackstack
 import si.inova.kotlinova.navigation.sample.keys.MainScreenKey

--- a/navigation/sample/shared-viewmodel/src/main/java/si/inova/kotlinova/navigation/sample/sharedviewmodel/SharedViewModelScreen.kt
+++ b/navigation/sample/shared-viewmodel/src/main/java/si/inova/kotlinova/navigation/sample/sharedviewmodel/SharedViewModelScreen.kt
@@ -27,7 +27,6 @@ import kotlinx.coroutines.flow.update
 import si.inova.kotlinova.navigation.instructions.navigateTo
 import si.inova.kotlinova.navigation.navigator.Navigator
 import si.inova.kotlinova.navigation.sample.keys.SharedViewModelScreenKey
-import si.inova.kotlinova.navigation.sample.sharedviewmodel.SharedService
 import si.inova.kotlinova.navigation.screens.Screen
 
 class SharedViewModelScreen(

--- a/navigation/sample/slide-animation/src/main/java/si/inova/kotlinova/navigation/sample/sliding/SlideAnimationScreenDeepLinkHandler.kt
+++ b/navigation/sample/slide-animation/src/main/java/si/inova/kotlinova/navigation/sample/sliding/SlideAnimationScreenDeepLinkHandler.kt
@@ -22,7 +22,6 @@ import si.inova.kotlinova.navigation.deeplink.DeepLinkHandler
 import si.inova.kotlinova.navigation.deeplink.matchDeepLink
 import si.inova.kotlinova.navigation.di.OuterNavigationScope
 import si.inova.kotlinova.navigation.instructions.NavigationInstruction
-import si.inova.kotlinova.navigation.instructions.OpenScreen
 import si.inova.kotlinova.navigation.instructions.OpenScreenOrMoveToTop
 import si.inova.kotlinova.navigation.instructions.ReplaceBackstack
 import si.inova.kotlinova.navigation.sample.keys.MainScreenKey

--- a/navigation/sample/tabs/src/main/java/si/inova/kotlinova/navigation/sample/tabs/TabsDeepLinkHandler.kt
+++ b/navigation/sample/tabs/src/main/java/si/inova/kotlinova/navigation/sample/tabs/TabsDeepLinkHandler.kt
@@ -18,12 +18,10 @@ package si.inova.kotlinova.navigation.sample.tabs
 
 import android.net.Uri
 import com.squareup.anvil.annotations.ContributesMultibinding
-import com.squareup.anvil.annotations.ContributesTo
 import si.inova.kotlinova.navigation.deeplink.DeepLinkHandler
 import si.inova.kotlinova.navigation.deeplink.handleMultipleDeepLinks
 import si.inova.kotlinova.navigation.di.OuterNavigationScope
 import si.inova.kotlinova.navigation.instructions.NavigationInstruction
-import si.inova.kotlinova.navigation.instructions.OpenScreen
 import si.inova.kotlinova.navigation.instructions.OpenScreenOrMoveToTop
 import si.inova.kotlinova.navigation.instructions.ReplaceBackstack
 import si.inova.kotlinova.navigation.sample.keys.MainScreenKey

--- a/navigation/sample/tabs/src/main/java/si/inova/kotlinova/navigation/sample/tabs/subscreens/SubscreenA.kt
+++ b/navigation/sample/tabs/src/main/java/si/inova/kotlinova/navigation/sample/tabs/subscreens/SubscreenA.kt
@@ -18,7 +18,6 @@ package si.inova.kotlinova.navigation.sample.tabs.subscreens
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text

--- a/navigation/sample/tabs/src/main/java/si/inova/kotlinova/navigation/sample/tabs/subscreens/SubscreenB.kt
+++ b/navigation/sample/tabs/src/main/java/si/inova/kotlinova/navigation/sample/tabs/subscreens/SubscreenB.kt
@@ -18,7 +18,6 @@ package si.inova.kotlinova.navigation.sample.tabs.subscreens
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text

--- a/navigation/sample/tabs/src/main/java/si/inova/kotlinova/navigation/sample/tabs/subscreens/SubscreenC.kt
+++ b/navigation/sample/tabs/src/main/java/si/inova/kotlinova/navigation/sample/tabs/subscreens/SubscreenC.kt
@@ -18,7 +18,6 @@ package si.inova.kotlinova.navigation.sample.tabs.subscreens
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text


### PR DESCRIPTION
this fixes build fail from importing class that no longer exists