### PR TITLE
feat(gradle): use our own sarif merging task

### DIFF
--- a/config/libs.toml
+++ b/config/libs.toml
@@ -34,6 +34,7 @@ junit4 = "4.13.2"
 junit5 = "5.10.0"
 moshi = "1.15.0"
 retrofit = "2.9.0"
+sarif4k = "0.5.0"
 simpleStack = "2.8.0"
 tomlj = "1.1.0"
 turbine = "1.0.0"
@@ -90,6 +91,7 @@ kotlin-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-te
 kotlin-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 retrofit-moshi = { module = "com.squareup.retrofit2:converter-moshi", version.ref = "retrofit" }
+sarif4k = { module = "io.github.detekt.sarif4k:sarif4k", version.ref = "sarif4k" }
 simpleStack = { module = "com.github.Zhuinden:simple-stack", version.ref = "simpleStack" }
 tomlj = { module = "org.tomlj:tomlj", version.ref = "tomlj" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }

--- a/kotlinova-gradle/README.MD
+++ b/kotlinova-gradle/README.MD
@@ -89,7 +89,7 @@ After all of that, you can update all of your libraries with a single command:
 # Detekt sarif report merging
 
 This allows one-line enabling of the
-[Detekt's report merging mechanism](https://detekt.dev/docs/introduction/reporting/#merging-reports) that will setup detekt tasks
+sarif lint report mechanism that will setup detekt
 in this project with .sarif output and then merge output of all detekt tasks to `merge.sarif` file in top level project's root.
 
 ```kotlin
@@ -101,7 +101,7 @@ kotlinova {
 # Android Lint sarif report merging
 
 This allows one-line enabling of the
-[Detekt's report merging mechanism](https://detekt.dev/docs/introduction/reporting/#merging-reports) that will setup
+sarif lint report mechanism that will
 merge sarif output of all Android Lint tasks to `merge.sarif` file in top level project's root.
 
 ```kotlin
@@ -116,11 +116,7 @@ Note, that you still need to enable sarif manually in lint configuration:
 android {
    sarifReport = true
 }
-}
 ```
-
-Even if you don't use Detekt, you still need it on the classpath for this to work,
-since it is using merging mechanism from Detekt plugin
 
 # Detekt's pre-commit hook
 

--- a/kotlinova-gradle/build.gradle.kts
+++ b/kotlinova-gradle/build.gradle.kts
@@ -135,6 +135,7 @@ dependencies {
    implementation(libs.googleCloud.monitoring)
    implementation(libs.googleCloud.protobufUtil)
    implementation(libs.orgJson)
+   implementation(libs.sarif4k)
    implementation(libs.tomlj)
 
    // Declare those dependencies as compile only to ensure they do not leak to consumers that do not need them

--- a/kotlinova-gradle/src/main/kotlin/si/inova/kotlinova/gradle/sarifmerge/SarifMergeTask.kt
+++ b/kotlinova-gradle/src/main/kotlin/si/inova/kotlinova/gradle/sarifmerge/SarifMergeTask.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2024 INOVA IT d.o.o.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software
+ *  is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ *  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ *   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package si.inova.kotlinova.gradle.sarifmerge
+
+import io.github.detekt.sarif4k.Level
+import io.github.detekt.sarif4k.PropertyBag
+import io.github.detekt.sarif4k.ReportingConfiguration
+import io.github.detekt.sarif4k.Run
+import io.github.detekt.sarif4k.SarifSchema210
+import io.github.detekt.sarif4k.SarifSerializer
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * A gradle task that merges sarif reports into one.
+ *
+ * Based on https://github.com/detekt/detekt/blob/ace6e4e5de07532416e89abf811ba37e0ea2b565/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeTask.kt
+ */
+@CacheableTask
+abstract class SarifMergeTask : DefaultTask() {
+   @get:InputFiles
+   @get:PathSensitive(PathSensitivity.RELATIVE)
+   abstract val input: ConfigurableFileCollection
+
+   @get:OutputFile
+   abstract val output: RegularFileProperty
+
+   @TaskAction
+   fun merge() {
+      val sarifFiles = input.files.filter { it.exists() }.map { SarifSerializer.fromJson(it.readText()) }
+
+      val merged = sarifFiles.reduce(SarifSchema210::merge)
+
+      // Workaround for the https://github.com/security-alert/security-alert/issues/50
+      val fixedSeverity = merged.copy(
+         runs = merged.runs.map { run ->
+            run.copy(
+               tool = run.tool.copy(
+                  driver = run.tool.driver.copy(
+                     rules = run.tool.driver.rules?.map { rule ->
+                        if (rule.defaultConfiguration?.level == null) {
+                           rule.copy(
+                              defaultConfiguration = ReportingConfiguration(level = Level.Warning)
+                           )
+                        } else {
+                           rule
+                        }
+                     }
+                  )
+               )
+            )
+         }
+      )
+
+      output.get().asFile.writeText(SarifSerializer.toJson(fixedSeverity))
+   }
+}
+
+private fun SarifSchema210.merge(other: SarifSchema210): SarifSchema210 {
+   require(schema == other.schema) {
+      "Cannot merge sarifs with different schemas: '${schema ?: "null"}' or '${other.schema ?: "null"}'"
+   }
+   require(version == other.version) {
+      "Cannot merge sarifs with different versions: '$version' or '${other.version}'"
+   }
+
+   val mergedExternalProperties = (inlineExternalProperties.orEmpty() + other.inlineExternalProperties.orEmpty())
+      .takeIf { it.isNotEmpty() }
+
+   val mergedProperties = properties.merge(other.properties)
+
+   val mergedRuns = runs.merge(other.runs)
+
+   return SarifSchema210(
+      schema,
+      version,
+      mergedExternalProperties,
+      mergedProperties,
+      mergedRuns
+   )
+}
+
+// Temporary copy from https://github.com/detekt/sarif4k/pull/87 until new version of sarif4k with that included is released
+
+private fun PropertyBag?.merge(other: PropertyBag?): PropertyBag? {
+   return (this?.tags.orEmpty() + other?.tags.orEmpty())
+      .takeIf { it.isNotEmpty() }
+      ?.let { PropertyBag(it) }
+}
+
+private fun List<Run>.merge(other: List<Run>): List<Run> {
+   val runsByTool = (this + other).groupBy { it.tool.driver.fullName }
+
+   return runsByTool.mapValues { (_, runs) ->
+      val baseRun = runs.firstOrNull() ?: return@mapValues null
+
+      val mergedResults = runs.flatMap { it.results.orEmpty() }
+      val mergedRules = runs.flatMap { it.tool.driver.rules.orEmpty() }.distinctBy { it.id }
+
+      baseRun.copy(
+         results = mergedResults,
+         tool = baseRun.tool.copy(
+            driver = baseRun.tool.driver.copy(
+               rules = mergedRules
+            )
+         )
+      )
+   }.values.filterNotNull().toList()
+}

--- a/kotlinova-gradle/src/main/kotlin/si/inova/kotlinova/gradle/sarifmerge/SarifMerging.kt
+++ b/kotlinova-gradle/src/main/kotlin/si/inova/kotlinova/gradle/sarifmerge/SarifMerging.kt
@@ -18,7 +18,6 @@ package si.inova.kotlinova.gradle.sarifmerge
 
 import com.android.build.gradle.internal.lint.AndroidLintTask
 import io.gitlab.arturbosch.detekt.Detekt
-import io.gitlab.arturbosch.detekt.report.ReportMergeTask
 import org.gradle.api.Project
 import org.gradle.api.UnknownTaskException
 import org.gradle.api.file.RegularFile
@@ -26,14 +25,14 @@ import org.gradle.api.tasks.TaskProvider
 import si.inova.kotlinova.gradle.KotlinovaExtension
 import java.io.File
 
-internal fun Project.createTopLevelMergeTask(): TaskProvider<ReportMergeTask> {
+internal fun Project.createTopLevelMergeTask(): TaskProvider<SarifMergeTask> {
    // This violates build isolation but we are forced to use it for performance reasons
    // Waiting for https://github.com/gradle/gradle/issues/25179 for a possible workaround
 
    return try {
-      rootProject.tasks.named("reportMerge", ReportMergeTask::class.java)
+      rootProject.tasks.named("reportMerge", SarifMergeTask::class.java)
    } catch (ignored: UnknownTaskException) {
-      rootProject.tasks.register("reportMerge", ReportMergeTask::class.java) { task ->
+      rootProject.tasks.register("reportMerge", SarifMergeTask::class.java) { task ->
          task.output.set(File(rootProject.rootDir, "merge.sarif"))
 
          task.doFirst {


### PR DESCRIPTION
this task has a better multi-tool handling than detekt's task and includes a workaround for missing levels in rules